### PR TITLE
chore(ci): drop python 3.6 from test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,14 +21,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # python 3.6
-          - python-version: '3.6'
-            ansible-version: '2.10.7'
-          - python-version: '3.6'
-            ansible-version: '3.4.0'
-          - python-version: '3.6'
-            ansible-version: '4.10.0'
-
           # python 3.7
           - python-version: '3.7'
             ansible-version: '2.10.7'

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This ansible module is tested against the following versions:
 
  | Program   | Compatible versions                                                       |
  | --------- | ------------------------------------------------------------------------- |
- | `ansible` | `2.10.7`, `3.4.0`, `4.10.0`, `5.10.0`, `6.7.0`, `7.7.0`, `8.7.0`, `9.7.0` |
- | `python`  | `3.6.x`, `3.7.x`, `3.8.x`, `3.9.x`, `3.10.x`, `3.11.x`, `3.12.x`          |
+ | `ansible` | `2.10.7`, `3.4.0`, `4.10.0`, `5.4.0`, `6.7.0`, `7.7.0`, `8.7.0`, `9.7.0`   |
+ | `python`  | `3.7.x`, `3.8.x`, `3.9.x`, `3.10.x`, `3.11.x`, `3.12.x`                   |
  | `stow`    | `2.3.1`, `2.4.0`                                                          |
 
 For `python < 3` (legacy systems that still uses `2.x`), use the [`v0.1.3`][ansible-stow-legacy] of this module.


### PR DESCRIPTION
Python 3.6 is not available on ubuntu-22.04 runners, which causes setup-python to fail. This removes the 3.6 combos from the tests matrix to keep CI green.